### PR TITLE
Add Danube Tech's ld-signatures-java implementation.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,3 +7,10 @@ services:
       dockerfile: Dockerfile
     volumes:
       - ./data:/data
+  danubetech:
+    image: danubetech/ldsignatures-test-jws
+    build:
+      context: ./implementations/danubetech
+      dockerfile: Dockerfile
+    volumes:
+      - ./data:/data

--- a/implementations/danubetech/Dockerfile
+++ b/implementations/danubetech/Dockerfile
@@ -1,0 +1,20 @@
+FROM maven:3-jdk-11 AS build
+MAINTAINER Markus Sabadello <markus@danubetech.com>
+
+ADD pom.xml /opt/ldsignatures-test-jws/
+RUN cd /opt/ldsignatures-test-jws && mvn dependency:resolve && mvn dependency:resolve-plugins
+ADD . /opt/ldsignatures-test-jws
+RUN cd /opt/ldsignatures-test-jws && mvn package
+
+FROM openjdk:11-jre-slim
+MAINTAINER Markus Sabadello <markus@danubetech.com>
+
+RUN export DEBIAN_FRONTEND=noninteractive && \
+    apt-get -y update && \
+    apt-get install -y --no-install-recommends apt-utils && \
+    apt-get install -y --no-install-recommends libsodium23 && \
+    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+COPY --from=build /opt/ldsignatures-test-jws/target/*.jar /opt/ldsignatures-test-jws/
+
+ENTRYPOINT [ "java", "-jar", "/opt/ldsignatures-test-jws/ldsignatures.test.jws-0.1-SNAPSHOT-jar-with-dependencies.jar" ]

--- a/implementations/danubetech/pom.xml
+++ b/implementations/danubetech/pom.xml
@@ -1,0 +1,68 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>com.danubetech</groupId>
+	<artifactId>ldsignatures.test.jws</artifactId>
+	<version>0.1-SNAPSHOT</version>
+	<packaging>jar</packaging>
+
+	<repositories>
+		<repository>
+			<id>danubetech-maven-public</id>
+			<url>https://repo.danubetech.com/repository/maven-public/</url>
+		</repository>
+	</repositories>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>2.3.2</version>
+				<configuration>
+					<source>11</source>
+					<target>11</target>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-assembly-plugin</artifactId>
+				<version>3.3.0</version>
+				<configuration>
+					<descriptorRefs>
+						<descriptorRef>jar-with-dependencies</descriptorRef>
+					</descriptorRefs>
+					<archive>
+						<manifest>
+							<mainClass>ldsignatures.test.jws.JWSTestSuite</mainClass>
+						</manifest>
+					</archive>
+				</configuration>
+				<executions>
+					<execution>
+						<id>make-assembly</id>
+						<phase>package</phase>
+						<goals>
+							<goal>single</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+
+	<dependencies>
+		<dependency>
+			<groupId>info.weboftrust</groupId>
+			<artifactId>ld-signatures-java</artifactId>
+			<version>0.5-SNAPSHOT</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-slf4j-impl</artifactId>
+			<version>2.13.3</version>
+		</dependency>
+	</dependencies>
+
+</project>

--- a/implementations/danubetech/src/main/java/ldsignatures.test.jws/JWSTestSuite.java
+++ b/implementations/danubetech/src/main/java/ldsignatures.test.jws/JWSTestSuite.java
@@ -1,0 +1,119 @@
+package ldsignatures.test.jws;
+
+import com.danubetech.keyformats.JWK_to_PrivateKey;
+import com.danubetech.keyformats.crypto.ByteSigner;
+import com.danubetech.keyformats.crypto.PrivateKeySignerFactory;
+import com.danubetech.keyformats.jose.JWK;
+import com.danubetech.keyformats.jose.KeyTypeName;
+import com.danubetech.keyformats.keytypes.KeyTypeName_for_JWK;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import foundation.identity.jsonld.JsonLDException;
+import foundation.identity.jsonld.JsonLDObject;
+import info.weboftrust.ldsignatures.jsonld.LDSecurityKeywords;
+import info.weboftrust.ldsignatures.signer.JsonWebSignature2020LdSigner;
+import info.weboftrust.ldsignatures.suites.SignatureSuites;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.OpenOption;
+import java.nio.file.Paths;
+import java.security.GeneralSecurityException;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.Map;
+
+public class JWSTestSuite {
+
+    static boolean isCredentialCreate(String[] args) {
+        return args != null && "credential".equals(args[0]) && "create".equals(args[1]);
+    }
+
+    static boolean isPresentationCreate(String[] args) {
+        return args != null && "presentation".equals(args[0]) && "create".equals(args[1]);
+    }
+
+    static String getParamValue(String[] args, String paramName) {
+        for (int i=0; i<args.length-1; i++) {
+            if (args[i].equals(paramName)) return args[i+1];
+        }
+        return null;
+    }
+
+    static String readFile(String path) throws IOException {
+        return path == null ? null : Files.readString(Paths.get(path));
+    }
+
+    static void writeFile(String path, String content) throws IOException {
+        Files.createDirectories(Paths.get(path).getParent());
+        Files.writeString(Paths.get(path), content, StandardCharsets.UTF_8);
+    }
+
+    static Map<String, Object> readKeyMap(String key) throws IOException {
+        ObjectMapper objectMapper = new ObjectMapper();
+        Map<String, Object> keyMap = objectMapper.readValue(key, Map.class);
+        if (keyMap == null) throw new IllegalArgumentException("No key map found: " + key);
+        return keyMap;
+    }
+
+    static URI readVerificationMethod(Map<String, Object> keyMap) throws IOException {
+        URI verificationMethod = keyMap == null ? null : URI.create((String) keyMap.get("id"));
+        if (verificationMethod == null) throw new IllegalArgumentException("No id found: " + keyMap);
+        return verificationMethod;
+    }
+
+    static JWK readJwk(Map<String, Object> keyMap, boolean privateKeyJwk) throws IOException {
+        Map<String, Object> jwkMap = keyMap == null ? null : (Map<String, Object>) keyMap.get(privateKeyJwk ? "privateKeyJwk" : "publicKeyJwk");
+        JWK keyJwk = jwkMap == null ? null : JWK.fromMap(jwkMap);
+        if (keyJwk == null) throw new IllegalArgumentException("No key found (" + privateKeyJwk + "): " + keyMap);
+        return keyJwk;
+    }
+
+    static void create(String input, String key, String outputFilename) throws JsonLDException, GeneralSecurityException, IOException {
+        JsonLDObject jsonLDObject = JsonLDObject.fromJson(input);
+        Map<String, Object> keyMap = readKeyMap(key);
+        URI verificationMethod = readVerificationMethod(keyMap);
+        JWK jwk = readJwk(keyMap, true);
+        KeyTypeName keyTypeName = KeyTypeName_for_JWK.keyTypeName_for_JWK(jwk);
+        String algorithm = SignatureSuites.SIGNATURE_SUITE_JSONWEBSIGNATURE2020.findDefaultJwsAlgorithmForKeyTypeName(keyTypeName);
+        Object privateKey = JWK_to_PrivateKey.JWK_to_anyPrivateKey(jwk);
+        ByteSigner byteSigner = PrivateKeySignerFactory.privateKeySignerForKey(keyTypeName, algorithm, privateKey);
+        JsonWebSignature2020LdSigner jsonWebSignature2020LdSigner = new JsonWebSignature2020LdSigner();
+        jsonWebSignature2020LdSigner.setVerificationMethod(verificationMethod);
+        jsonWebSignature2020LdSigner.setCreated(new Date());
+        jsonWebSignature2020LdSigner.setProofPurpose(LDSecurityKeywords.JSONLD_TERM_ASSERTIONMETHOD);
+        jsonWebSignature2020LdSigner.setSigner(byteSigner);
+        jsonWebSignature2020LdSigner.sign(jsonLDObject, true, false);
+        String output = jsonLDObject.toJson(true);
+        writeFile(outputFilename, output);
+    }
+
+    static void credentialCreate(String input, String key, String outputFilename) throws JsonLDException, GeneralSecurityException, IOException {
+        create(input, key, outputFilename);
+    }
+
+    static void presentationCreate(String input, String key, String outputFilename) throws JsonLDException, GeneralSecurityException, IOException {
+        create(input, key, outputFilename);
+    }
+
+    public static void main(String[] args) throws Throwable {
+
+        String inputFilename = getParamValue(args, "--input");
+        String outputFilename = getParamValue(args, "--output");
+        String keyFilename = getParamValue(args, "--key");
+        if (inputFilename == null) throw new IllegalArgumentException("No input filename.");
+        if (outputFilename == null) throw new IllegalArgumentException("No output filename.");
+        if (keyFilename == null) throw new IllegalArgumentException("No key filename.");
+
+        String input = readFile(inputFilename);
+        String key = readFile(keyFilename);
+
+        if (isCredentialCreate(args))
+            credentialCreate(input, key, outputFilename);
+        else if (isPresentationCreate(args))
+            presentationCreate(input, key, outputFilename);
+        else
+            throw new IllegalArgumentException("Invalid request: " + Arrays.asList(args));
+    }
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "generate.js",
   "scripts": {
     "build": "docker-compose build",
-    "report:clean": "rm -rf ./data/implementations/transmute/*.json",
+    "report:clean": "rm -rf ./data/implementations/transmute/*.json ./data/implementations/danubetech/*.json",
     "report:generate": "node ./generate.js"
   },
   "repository": {


### PR DESCRIPTION
This adds our implementation: https://github.com/weboftrustinfo/ld-signatures-java

It's in Java and therefore a bit slow :)

It only supports Ed25519 and secp256k1 right now.

I'm not sure if the results are actually "correct", so I'd definitely be interested in also testing the verification part.

Fixes #6 .