### PR TITLE
Catch async evaluation errors

### DIFF
--- a/evaluate.js
+++ b/evaluate.js
@@ -103,4 +103,7 @@ const extendIndexWithEvaluations = async (index) => {
     indexOutputPath,
     JSON.stringify(implementationResults, null, 2)
   );
-})();
+})().catch((e) => {
+  console.error(e)
+  process.exit(1)
+});


### PR DESCRIPTION
Build failure in evaluate.js passes unnotices because error goes to UnhandledPromiseRejectionWarning and exit status is zero:
<https://github.com/decentralized-identity/JWS-Test-Suite/runs/4213002882?check_suite_focus=true#step:8:23>

Fix by handling the unhandled promise rejection.
More info: https://jonasjancarik.medium.com/handling-those-unhandled-promise-rejections-when-using-javascript-async-await-and-ifee-5bac52a0b29f