### PR TITLE
Verify RSA using Spruce/ssi implementation

### DIFF
--- a/evaluate.js
+++ b/evaluate.js
@@ -99,6 +99,8 @@ const extendIndexWithEvaluations = async (index) => {
     "./data/implementations/index.json"
   );
 
+  // Sanitize results for stringification.
+  // https://github.com/transmute-industries/verifiable-data/issues/120
   for (const imp in implementationResults) {
     for (const k in implementationResults[imp]) {
       delete implementationResults[imp][k].verification.error
@@ -106,6 +108,7 @@ const extendIndexWithEvaluations = async (index) => {
       delete implementationResults[imp][k].verification.presentation
     }
   }
+
   fs.writeFileSync(
     indexOutputPath,
     JSON.stringify(implementationResults, null, 2)

--- a/evaluate.js
+++ b/evaluate.js
@@ -3,6 +3,7 @@ console.log("\n🔎 Preparing evaluation report...\n");
 const path = require("path");
 const fs = require("fs");
 const { verify } = require("./implementations/transmute/cli");
+const verifyRSA = require("./implementations/spruce/verify");
 const implementationsReport = path.join(__dirname, "./data/implementations");
 
 const buildImplementationsIndex = () => {
@@ -75,7 +76,10 @@ const extendIndexWithEvaluations = async (index) => {
         }
       }
 
-      const verification = await verify(vectorContent, format);
+      const isRSA =/-rsa\d/.test(vector);
+      const verification = isRSA
+        ? await verifyRSA(vectorContent, format)
+        : await verify(vectorContent, format);
 
       index[implementation][vector] = {
         vector: format,

--- a/implementations/spruce/Cargo.toml
+++ b/implementations/spruce/Cargo.toml
@@ -12,3 +12,4 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 async-trait = "0.1"
 thiserror = "1.0"
+atty = "0.2"

--- a/implementations/spruce/src/main.rs
+++ b/implementations/spruce/src/main.rs
@@ -307,6 +307,12 @@ async fn main() -> Result<(), std::io::Error> {
             let input_file = File::open(input)?;
             let input_reader = BufReader::new(input_file);
             let mut presentation: Presentation = serde_json::from_reader(input_reader)?;
+            if let Some(existing_holder) = presentation.holder {
+                if existing_holder.to_string() != key.controller {
+                    panic!("Presentation already has different holder");
+                }
+            }
+            presentation.holder = Some(ssi::vc::URI::String(key.controller.to_string()));
 
             let private_key_jwk = key.private_key_jwk.clone();
             let mut options = LinkedDataProofOptions {

--- a/implementations/spruce/verify.js
+++ b/implementations/spruce/verify.js
@@ -1,0 +1,27 @@
+const proc = require('child_process');
+const util = require('util');
+
+module.exports = util.promisify(async function (doc, format, cb) {
+	const isJwt = format.endsWith('-jwt');
+	const type = format === 'vc' || format == 'vc-jwt' ? 'credential'
+		: format === 'vp' || format == 'vp-jwt' ? 'presentation'
+		: null;
+	if (!type) throw new Error('Unknown format: ' + format);
+	const data = JSON.stringify(isJwt ? {jwt: doc} : doc);
+	const child = proc.spawn('docker-compose', [
+		'run', 'spruce', type, 'verify',
+		'--format', format
+	], {
+		stdio: ['pipe', 'pipe', 'inherit']
+	});
+	let bufs = [];
+	child.stdout.on('data', (buf) => bufs.push(buf));
+	child.on('close', (code) => {
+		if (code !== 0) {
+			return cb(new Error('Failed to verify (' + code + ')'));
+		}
+		const data = Buffer.concat(bufs).toString('utf8');
+		cb(null, JSON.parse(data));
+	});
+	child.stdin.end(data);
+});


### PR DESCRIPTION
This updates the test suite to use Spruce's Rust/ssi implementation to verify RSA VCs/VPs. This enables the RSA VCs/VPs to be verified and show in the report as such, since the main verifier implementation (Transmute's) doesn't have support for them currently.

A helper script is added to run Spruce's CLI verify function from JS. This slows down running `generate.js` a bit, since running a new Docker command for each operation is slow. To improve this, the implementation could be built on the host system rather than in Docker and then copy the binary into the Docker image - like how Transmute's implementation does it. The helper script could also be generalized to work with other implementations. It depends on making the `--input (-i)` and `--output (-o)` options optional, defaulting to standard input/output respectively (Alternatively temp files could be used.)