### PR TITLE
Handle verification failure in spruce/verify

### DIFF
--- a/implementations/spruce/verify.js
+++ b/implementations/spruce/verify.js
@@ -18,7 +18,7 @@ module.exports = util.promisify(async function (doc, format, cb) {
 	child.stdout.on('data', (buf) => bufs.push(buf));
 	child.on('close', (code) => {
 		if (code !== 0) {
-			return cb(new Error('Failed to verify (' + code + ')'));
+			return cb(null, {verified: false, code})
 		}
 		const data = Buffer.concat(bufs).toString('utf8');
 		cb(null, JSON.parse(data));


### PR DESCRIPTION
Return verification failure object instead of throwing error.

Address #40

https://github.com/spruceid/JWS-Test-Suite/runs/5012336364
https://spruceid.github.io/JWS-Test-Suite/