### PR TITLE
Add did-jwt-vc tests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,3 +28,10 @@ services:
       dockerfile: Dockerfile
     volumes:
       - ./data:/data
+  did-jwt-vc:
+    image: did-jwt-vc/jws-test-suite-cli
+    build:
+      context: ./implementations/did-jwt-vc
+      dockerfile: Dockerfile
+    volumes:
+      - ./data:/data

--- a/implementations/did-jwt-vc/Dockerfile
+++ b/implementations/did-jwt-vc/Dockerfile
@@ -1,0 +1,25 @@
+
+FROM node:14.15.3 as build
+
+USER node
+WORKDIR /home/node
+
+COPY package*.json ./
+COPY --chown=node:node . .
+
+RUN npm ci --only=production
+
+FROM node:14.15.3-alpine3.10 as cli
+
+WORKDIR /home/node
+
+COPY --from=build /home/node/node_modules ./node_modules
+COPY --from=build /home/node/package.json ./package.json
+COPY --from=build /home/node/cli.js ./cli.js
+COPY --from=build /home/node/did-jwt-vc-runner.js ./did-jwt-vc-runner.js
+COPY --from=build /home/node/bin.js ./bin.js
+
+# disable warning related to mattr libraries.
+ENV NODE_NO_WARNINGS=1
+
+ENTRYPOINT [ "node", "bin.js" ]

--- a/implementations/did-jwt-vc/Dockerfile
+++ b/implementations/did-jwt-vc/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /home/node
 COPY package*.json ./
 COPY --chown=node:node . .
 
-RUN npm ci --only=production
+RUN npm install --production
 
 FROM node:14.15.3-alpine3.10 as cli
 

--- a/implementations/did-jwt-vc/bin.js
+++ b/implementations/did-jwt-vc/bin.js
@@ -1,0 +1,92 @@
+const yargs = require("yargs");
+const cli = require("./cli");
+yargs.scriptName("✨");
+
+
+yargs.command(
+  "presentation [action]",
+  "Create a verifiable presentation",
+  {
+    input: {
+      alias: "i",
+      description: "Path to input document",
+      demandOption: true,
+    },
+    output: {
+      alias: "o",
+      description: "Path to output document",
+      demandOption: true,
+    },
+    key: {
+      alias: "k",
+      description: "Path to key",
+    },
+    format: {
+      alias: "f",
+      description: "Output format",
+      default: "vp",
+    },
+  },
+  async (argv) => {
+    if (argv.action === "create") {
+      await cli.createVerifiablePresentation({
+        input: argv.input,
+        output: argv.output,
+        format: argv.format,
+        key: argv.key,
+      });
+    }
+    if (argv.action === "verify") {
+      await cli.verifyVerifiablePresentation({
+        input: argv.input,
+        output: argv.output,
+        format: argv.format,
+      });
+    }
+  }
+);
+
+yargs.command(
+  "credential [action]",
+  "verifiable credentials api",
+  {
+    input: {
+      alias: "i",
+      description: "Path to input document",
+      demandOption: true,
+    },
+    output: {
+      alias: "o",
+      description: "Path to output document",
+      demandOption: true,
+    },
+    key: {
+      alias: "k",
+      description: "Path to key",
+    },
+    format: {
+      alias: "f",
+      description: "Input format",
+      default: "vc-jwt",
+    },
+  },
+  async (argv) => {
+    if (argv.action === "create") {
+      await cli.createVerifiableCredential({
+        input: argv.input,
+        output: argv.output,
+        format: argv.format,
+        key: argv.key,
+      });
+    }
+    if (argv.action === "verify") {
+      await cli.verifyVerifiableCredential({
+        input: argv.input,
+        output: argv.output,
+        format: argv.format,
+      });
+    }
+  }
+);
+
+yargs.help().alias("help", "h").demandCommand().argv;

--- a/implementations/did-jwt-vc/cli.js
+++ b/implementations/did-jwt-vc/cli.js
@@ -1,0 +1,86 @@
+const fs = require("fs");
+
+const loadJsonFile = (absolutePath) => {
+  return JSON.parse(fs.readFileSync(absolutePath).toString());
+};
+
+const { createVcJwt, createVpJwt } = require("./did-jwt-vc-runner");
+
+const createVerifiableCredential = async ({ input, output, key, format }) => {
+  let credentialJson;
+  try {
+    credentialJson = loadJsonFile(input);
+  } catch (e) {
+    console.error("Could not load credential json from path: " + input);
+    return;
+  }
+  try {
+    keyJson = loadJsonFile(key);
+  } catch (e) {
+    console.error("Could not load key json from path: " + key);
+    return;
+  }
+
+  if (format.includes("jwt")) {
+    outputJson = { jwt: await createVcJwt(credentialJson, keyJson) };
+  } else {
+    outputJson = { jwt: "" };
+  }
+  fs.writeFileSync(output, JSON.stringify(outputJson, null, 2));
+};
+
+const createVerifiablePresentation = async ({ input, output, key, format }) => {
+  let presentationJson;
+  try {
+    presentationJson = loadJsonFile(input);
+  } catch (e) {
+    console.error("Could not load presentation json from path: " + input);
+    return;
+  }
+  try {
+    keyJson = loadJsonFile(key);
+  } catch (e) {
+    console.error("Could not load key json from path: " + key);
+    return;
+  }
+
+  if (format.includes("jwt")) {
+    outputJson = { jwt: await createVpJwt(presentationJson, keyJson) };
+  } else {
+    outputJson = { jwt: "" };
+  }
+  fs.writeFileSync(output, JSON.stringify(outputJson, null, 2));
+
+};
+
+const verifyVerifiableCredential = async ({ input, output, format }) => {
+  let credentialJson;
+  try {
+    credentialJson = loadJsonFile(input);
+  } catch (e) {
+    console.error("Could not load credential json from path: " + input);
+    return;
+  }
+  const result = await verify(credentialJson, format);
+  fs.writeFileSync(output, JSON.stringify(result, null, 2));
+};
+
+const verifyVerifiablePresentation = async ({ input, output, format }) => {
+  let presentationJson;
+  try {
+    presentationJson = loadJsonFile(input);
+  } catch (e) {
+    console.error("Could not load presentation json from path: " + input);
+    return;
+  }
+  const result = await verify(presentationJson, format);
+  fs.writeFileSync(output, JSON.stringify(result, null, 2));
+};
+
+
+module.exports = {
+  createVerifiableCredential,
+  createVerifiablePresentation,
+  verifyVerifiableCredential, 
+  verifyVerifiablePresentation
+};

--- a/implementations/did-jwt-vc/did-jwt-vc-runner.js
+++ b/implementations/did-jwt-vc/did-jwt-vc-runner.js
@@ -1,0 +1,129 @@
+const { createVerifiableCredentialJwt, createVerifiablePresentationJwt, verifyCredential, verifyPresentation } = require("did-jwt-vc")
+const moment = require("moment")
+const { EdDSASigner, ES256KSigner, EllipticSigner } = require("did-jwt")
+const base64url = require("base64url");
+
+const BASE58 = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+const bs58 = require("base-x")(BASE58);
+
+function privateKeyJwkToPrivateKeyBase58(buffer) {
+  const privateKeyBase58 = bs58.encode(buffer);
+  return privateKeyBase58;
+}
+
+function buildIssuer(did, privateKeyJwk) {
+  let theSigner = null
+  let alg = null
+ if (privateKeyJwk.kty === 'OKP' && privateKeyJwk.crv === 'Ed25519') {
+    const buffer = Buffer.concat([
+      base64url.toBuffer(privateKeyJwk.d),
+      base64url.toBuffer(privateKeyJwk.x)
+    ])
+    const pk = privateKeyJwkToPrivateKeyBase58(buffer)
+    theSigner = new EdDSASigner(pk)
+    alg = 'EdDSA'
+  } 
+  /*
+  if (privateKeyJwk.kty === 'EC') {
+  const pk = keyto.from( JSON.stringify(privateKeyJwk), 'jwk').toString('blk', 'private')
+  theSigner = new ES256KSigner(pk)
+  if (privateKeyJwk.crv === 'secp256k1') {
+    alg = 'ES256K'
+  } else if (privateKeyJwk.crv === 'P-256') {
+    alg = 'ES256'
+  }
+}
+else if (privateKeyJwk.kty === 'RSA') {
+    theSigner = new EllipticSigner(pk)
+    alg = 'PS256'
+  }
+*/
+  if (!theSigner) {
+    return null;
+  }
+  
+  return {
+    did: did,
+    signer: theSigner,
+    alg: alg
+  }
+}
+
+function toCredentialPayload(credential) {
+  const payload = { vc: credential }
+  if (credential.id) {
+    payload.jti = credential.id
+  }
+  if (credential.issuanceDate) {
+    payload.nbf = moment.utc(credential.issuanceDate).unix()
+  }
+  if (credential.expirationDate) {
+    payload.exp = moment.utc(credential.expirationDate).unix()
+  }
+  if (credential.issuer) {
+    payload.iss =
+      typeof credential.issuer === "string"
+        ? credential.issuer
+        : credential.issuer.id
+  }
+  if (credential.credentialSubject.id) {
+    payload.sub = credential.credentialSubject.id
+  }
+  return payload
+}
+
+function toPresentationPayload(presentation, identifier) {
+
+  const payload = {
+    vp: presentation
+  }
+
+  payload.vp.holder = identifier
+  payload.iss = identifier
+  payload.sub = identifier
+  payload.nonce = "123"
+  return payload
+}
+
+function createOptions(kid) {
+  const options = {};
+  options.header = {};
+  options.header.kid = kid;
+  return options;
+}
+
+
+const createVcJwt = async (credential, key) => {
+  const identifier = key.id.split("#")[0]
+  const issuer = buildIssuer(identifier, key.privateKeyJwk)
+  if (!issuer) return {}
+  
+  const payload = toCredentialPayload(credential)
+  const options = createOptions(key.id);
+  const vcJwt = await createVerifiableCredentialJwt(payload, issuer, options)
+  return vcJwt;
+}
+
+const createVpJwt = async(presentation, key) => {
+  const identifier = key.id.split("#")[0]
+  const issuer = buildIssuer(identifier, key.privateKeyJwk)
+  if (!issuer) return {}
+
+  const vpPayload = toPresentationPayload(presentation, identifier)
+  const options = createOptions(key.id);
+  
+  const vpJwt = await createVerifiablePresentationJwt(vpPayload, issuer, options)
+  return vpJwt
+}
+
+const verifyVcJwt = async (credential, format) => {
+
+  //const didResolver = new ExampleResolver()
+
+  //const verifiedVC = await verifyCredential(credential, didResolver)
+  return {}
+}
+
+
+module.exports = { createVcJwt, createVpJwt, verifyVcJwt };
+

--- a/implementations/did-jwt-vc/did-jwt-vc-runner.test.js
+++ b/implementations/did-jwt-vc/did-jwt-vc-runner.test.js
@@ -1,0 +1,27 @@
+//const rawKeyJson = require("../../data/keys/key-1-secp256k1.json");
+// const rawKeyJson = require("../../data/keys/key-2-secp256r1.json");
+// const rawKeyJson = require("../../data/keys/key-4-rsa2048.json");
+
+const rawKeyJson = require("../../data/keys/key-0-ed25519.json");
+
+const credential = require("../../data/credentials/credential-1.json");
+const presentation = require("../../data/presentations/presentation-0.json");
+const { createVcJwt, createVpJwt, verifyVcJwt } = require("./did-jwt-vc-runner");
+
+const vcJwt = "eyJraWQiOiJkaWQ6ZXhhbXBsZToxMjMja2V5LTAiLCJhbGciOiJFZERTQSIsInR5cCI6IkpXVCJ9.eyJleHAiOjE5MjUwNjE4MDQsInZjIjp7IkBjb250ZXh0IjpbImh0dHBzOi8vd3d3LnczLm9yZy8yMDE4L2NyZWRlbnRpYWxzL3YxIiwiaHR0cHM6Ly93M2lkLm9yZy9zZWN1cml0eS9zdWl0ZXMvandzLTIwMjAvdjEiLHsiQHZvY2FiIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS8jIn1dLCJ0eXBlIjpbIlZlcmlmaWFibGVDcmVkZW50aWFsIl0sImlzc3VlciI6ImRpZDpleGFtcGxlOjEyMyIsImlzc3VhbmNlRGF0ZSI6IjIwMjEtMDEtMDFUMTk6MjM6MjRaIiwiZXhwaXJhdGlvbkRhdGUiOiIyMDMxLTAxLTAxVDE5OjIzOjI0WiIsImNyZWRlbnRpYWxTdWJqZWN0Ijp7ImlkIjoiZGlkOmV4YW1wbGU6NDU2IiwidHlwZSI6IlBlcnNvbiJ9fSwibmJmIjoxNjA5NTI5MDA0LCJpc3MiOiJkaWQ6ZXhhbXBsZToxMjMiLCJzdWIiOiJkaWQ6ZXhhbXBsZTo0NTYifQ.Mmyv3dqhlmgaMtsLnHvCXVCVTL4z2ymoyuxMQjyqi9ex0aziv66MbJBF1um_aPvj_0GIlsvlzlu-JZIpbezlCw"
+describe("basicTests", () => {
+  it("can create a simple vc-jwt", async () => {
+    const jwt = await createVcJwt(credential, rawKeyJson);
+    expect(jwt).toBeDefined();
+  });
+
+  it("can create a simple vp-jwt", async () => {
+    const jwt = await createVpJwt(presentation, rawKeyJson);
+    expect(jwt).toBeDefined();
+  });
+
+  it("can verify a simple vc-jwt", async () => {
+    const result = await verifyVcJwt(vcJwt, "");
+    expect(result).toBeDefined();
+  });
+});

--- a/implementations/did-jwt-vc/package.json
+++ b/implementations/did-jwt-vc/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "did-jwt-vc-tests",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "cli": "node ./cli.js",
+    "test": "jest"
+  },
+  "author": "Kim Duffy",
+  "license": "MIT",
+  "devDependencies": {
+    "jest": "^27.2.2"
+  },
+  "dependencies": {
+    "@trust/keyto": "^1.0.1",
+    "alphabet": "^1.0.0",
+    "base58-universal": "^1.0.0",
+    "base64url": "^3.0.1",
+    "bs58": "^5.0.0",
+    "did-jwt": "^5.12.4",
+    "did-jwt-vc": "^2.1.9",
+    "did-resolver": "^3.1.5",
+    "ethr-did": "^2.2.0",
+    "key-did-resolver": "^1.4.4",
+    "moment": "^2.29.1",
+    "yargs": "^17.2.1"
+  }
+}


### PR DESCRIPTION
Added did-jwt-vc tests, focusing only on signing and ed25519 to start with. Skeleton of the rest is there.

Specifically, signing tests for the following pass:

- credential-1--key-0-ed25519.vc-jwt.json
- credential-2--key-0-ed25519.vc-jwt.json
- credential-3--key-0-ed25519.vc-jwt.json
- presentation-0--key-0-ed25519.vp-jwt.json
- presentation-1--key-0-ed25519.vp-jwt.json

Note that there is a lot of duplication with other js implementations (bin and cli). Addressing that seemed out of scope. 

As for implementing the rest -- this test suite is a little onerous so I had to timebox the work. But I included the framework so that it give subsequent people a good head start:
- Support for additional signers should be easy for someone with the JWK mappings in active recall.
- Verification should be straightforward if someone can add a did:example resolver