### PR TITLE
Fix implementation report table of contents

### DIFF
--- a/data/index.html
+++ b/data/index.html
@@ -165,8 +165,6 @@
           await generateImplementations();
         })();
       </script>
-
-      <div id="content-from-evaluation-index"></div>
     </section>
   </body>
 </html>

--- a/data/script.js
+++ b/data/script.js
@@ -31,7 +31,7 @@ var loadIndex = () => {
   });
 };
 
-const impContainer = "content-from-evaluation-index";
+const impContainer = "implementations";
 
 const pass = "✅ pass";
 const fail = "❌ fail";


### PR DESCRIPTION
This enables the implementation sections to appear in the web page's table of contents, for easier navigation.

There's still a race condition due to loading the contents asynchronously so sometimes the table of contents list items won't appear, but usually they do.

Looks like:
![2022-03-04-094650_362x885_scrot](https://user-images.githubusercontent.com/95347/156784364-84495486-66ff-4107-a668-ac0e6c5d3ee8.png)

