### PR TITLE
Update Spruce implementation for holderless VP and platform-independence

### DIFF
--- a/implementations/spruce/Cargo.toml
+++ b/implementations/spruce/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 publish = false
 
 [dependencies]
-ssi = { git = "https://github.com/spruceid/ssi", features = ["secp256k1", "secp256r1", "keccak-hash"] }
+ssi = { git = "https://github.com/spruceid/ssi", rev = "dbe7c07cc6790e16d9da263112fc4e680bc5bb1a", features = ["secp256k1", "secp256r1", "keccak-hash"] }
 structopt = "0.3"
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/implementations/spruce/Dockerfile
+++ b/implementations/spruce/Dockerfile
@@ -6,5 +6,5 @@ WORKDIR /ssi-jws
 RUN cargo build --release
 
 FROM alpine
-COPY --from=builder /ssi-jws/target/x86_64-unknown-linux-musl/release/ssi-jws ssi-jws
+COPY --from=builder /ssi-jws/target/*/release/ssi-jws ssi-jws
 ENTRYPOINT ["./ssi-jws"]

--- a/implementations/spruce/src/main.rs
+++ b/implementations/spruce/src/main.rs
@@ -341,12 +341,6 @@ async fn main() -> Result<(), std::io::Error> {
             let input_file = file_or_stdin(input)?;
             let input_reader = BufReader::new(input_file);
             let mut presentation: Presentation = serde_json::from_reader(input_reader)?;
-            if let Some(existing_holder) = presentation.holder {
-                if existing_holder.to_string() != key.controller {
-                    panic!("Presentation already has different holder");
-                }
-            }
-            presentation.holder = Some(ssi::vc::URI::String(key.controller.to_string()));
 
             let private_key_jwk = key.private_key_jwk.clone();
             let mut options = LinkedDataProofOptions {


### PR DESCRIPTION
Update `spruce` implementation and RSA verifier (#52) to allow verifiable presentation without holder property.

Referenced `ssi` library commit is from https://github.com/spruceid/ssi/pull/407.

Additionally, the `spruce` implementation is updated to no longer set the holder property during VP creation, for the following reasons:
- It's not required, as discussed in #52.
- It's already set (to the expected value) in presentation-1 and presentation-2.
- In presentation-0, generating the result without it allows for implementations to test the expected behavior of allowing its optionality.
- Not modifying the input VP - except to add the proof object - may be desirable.

Also, change the target directory reference to be architecture/platform-independent, for #50.