### PR TITLE
Use non-empty credential subject in embedded VC

### DIFF
--- a/data/presentations/presentation-2.json
+++ b/data/presentations/presentation-2.json
@@ -22,18 +22,23 @@
     {
       "@context": [
         "https://www.w3.org/2018/credentials/v1",
-        "https://w3id.org/security/suites/jws-2020/v1"
+        "https://w3id.org/security/suites/jws-2020/v1",
+        {
+          "@vocab": "https://example.com/#"
+        }
       ],
       "type": ["VerifiableCredential"],
       "issuer": "did:example:123",
-      "issuanceDate": "2021-01-01T19:23:24Z",
-      "credentialSubject": {},
+      "issuanceDate": "2022-03-19T15:20:55Z",
+      "credentialSubject": {
+        "foo": "bar"
+      },
       "proof": {
         "type": "JsonWebSignature2020",
-        "created": "2021-11-06T16:49:50Z",
+        "created": "2022-05-25T20:47:56Z",
         "verificationMethod": "did:example:123#key-0",
         "proofPurpose": "assertionMethod",
-        "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..-OM7P_1AXTqC2p8b5bejObwP7rc-pIFH5vbBJCUzLXAqSXtT_mPW0wJIEgyEP4AII_BygxefoA__eztwJu4fDw"
+        "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..UZDrVaA0AbuYimw6_751qMLeBWJf5Av1KJIuDSvusq42WDbfP75ID6dZ7tarz-fy8hHYYD4FR7T1OJvlVxFkBA"
       }
     }
   ]


### PR DESCRIPTION
Verifiable Presentation `presentation-2.json` contains an embedded Verifiable Credential which has an empty credentialSubject.
This causes an error in recent versions of the verifier implementation by Spruce (#61) where a VC with empty credentialSubject is now considered invalid.
Since Spruce's implementation is used for RSA verification here, this causes TBD's implementation (the other implementation with RSA) to fail to verify too.

This PR follows #57 to add a property to the credentialSubject (of the embedded VC in this case) so that the credentialSubject is not empty.

On my local system this fixes #61.